### PR TITLE
LIMS-2589 Added css to hide the user report on ALS

### DIFF
--- a/als/lims/profiles/default/cssregistry.xml
+++ b/als/lims/profiles/default/cssregistry.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<object name="portal_css">
+
+<stylesheet
+    id="++resource++als.lims.css/bika_overrides.css"
+    media="screen"
+    rel="stylesheet"
+    rendering="link"
+    insert-after="*"/>
+
+</object>

--- a/als/lims/static/css/bika_overrides.css
+++ b/als/lims/static/css/bika_overrides.css
@@ -1,0 +1,6 @@
+.template-administration #content-core div fieldset h2:nth-child(3){
+    display: none !important;
+}
+.template-administration #content-core div fieldset ul:nth-child(4){
+    display: none !important;
+}


### PR DESCRIPTION

## Description of the issue/feature this PR addresses
      Remove user activity report
      Please see https://github.com/bikalabs/bika.lims/pull/1959
https://jira.bikalabs.com/browse/LIMS-2589

## Current behavior before PR
     It was taking too long to run the activity report
## Desired behavior after PR is merged
     Taken/hidden out the user activity report link